### PR TITLE
Add support  lighter key derivation function

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Ethsigner provides the following features:
 ethsign --keystore </path/to/keystore>
 ```
 
+ethsign optionally accepts the `--lightkdf` flag.
+With this flag set it costs less resources to protect your keys at the expense of security.
+This is useful when ethsign is run on an environment with low resources.
+
 #### Create account
 ```
 > personal.newAccount()

--- a/main.go
+++ b/main.go
@@ -13,12 +13,18 @@ import (
 
 var (
 	keystoreLocation = flag.String("keystore", "", "keystore path")
+	lightKDF         = flag.Bool("lightkdf", false, "reduce key-derivation RAM & CPU usage at some expense of KDF strength")
 )
 
 func main() {
 	flag.Parse()
 
-	ks := keystore.NewKeyStore(*keystoreLocation, keystore.StandardScryptN, keystore.StandardScryptP)
+	n, p := keystore.StandardScryptN, keystore.StandardScryptP
+	if *lightKDF {
+		n, p = keystore.LightScryptN, keystore.LightScryptP
+	}
+
+	ks := keystore.NewKeyStore(*keystoreLocation, n, p)
 
 	handler := rpc.NewServer()
 	pers := &PersService{ks}


### PR DESCRIPTION
Add support for `--lightkdf` with the same semantics as the `--lightkdf` flag has in geth.